### PR TITLE
メニューバーの秒数を画像化

### DIFF
--- a/Uljika/MenuBarLayoutHelper.swift
+++ b/Uljika/MenuBarLayoutHelper.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+struct MenuBarLayoutHelper {
+    private static let measureFont = NSFont.monospacedDigitSystemFont(
+        ofSize: NSFont.systemFontSize,
+        weight: .regular
+    )
+    
+    private static let widestScheduleLabel: String = {
+        let labels = TimeCalculator.schedules.map(\.0)
+        return labels.max {
+            measuredWidth(of: $0) < measuredWidth(of: $1)
+        } ?? ""
+    }()
+    
+    private static let dummyLeftTime = "000:00"
+    // 念の為000:00　必要に応じて変更してください
+    
+    static func referenceTitle(for renderStyle: RenderStyle, fallbackText: String) -> String {
+        let styleReference: String
+        
+        switch renderStyle {
+        case .Normal:
+            styleReference = "\(widestScheduleLabel)まで\(dummyLeftTime)"
+        case .Compact:
+            styleReference = dummyLeftTime
+        case .Custom(let format):
+            styleReference = format
+                .replacingOccurrences(of: "{next.label}", with: widestScheduleLabel)
+                .replacingOccurrences(of: "{next.leftTime}", with: dummyLeftTime)
+        }
+        
+        return widestTitle(in: [styleReference, fallbackText], fallback: fallbackText)
+    }
+
+    private static func widestTitle(in titles: [String], fallback: String) -> String {
+        titles.max { measuredWidth(of: $0) < measuredWidth(of: $1) } ?? fallback
+    }
+
+    private static func measuredWidth(of title: String) -> CGFloat {
+        (title as NSString).size(withAttributes: [.font: measureFont]).width
+    }
+}

--- a/Uljika/MenuBarTitleLabel.swift
+++ b/Uljika/MenuBarTitleLabel.swift
@@ -4,51 +4,91 @@ import AppKit
 struct MenuBarTitleLabel: View {
     let title: String
     let referenceTitle: String
-    
-    // 好きなフォントがある場合はここで指定できるよ
-    
-    private func styledText(from string: String) -> Text {
-        let regex = /[0-9]+:[0-9]{2}/
-        var result = Text("")
-        
-        var currentIndex = string.startIndex
-        for match in string.matches(of: regex) {
-            result = result + Text(String(string[currentIndex..<match.range.lowerBound]))
-            // 数字部分だけ等幅にする
-            result = result + Text(String(string[match.range])).monospacedDigit()
-            currentIndex = match.range.upperBound
-        }
-        
-        result = result + Text(String(string[currentIndex...]))
-        return result
-    }
 
-    @MainActor
-    private func renderImage() -> NSImage? {
-        let layout = ZStack(alignment: .center) {
-            styledText(from: referenceTitle)
-                .hidden()
-
-            styledText(from: title)
-                .lineLimit(1)
-        }
-        .fixedSize()
-
-        let renderer = ImageRenderer(content: layout)
-        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
-
-        if let nsImage = renderer.nsImage {
-            nsImage.isTemplate = true
-            return nsImage
-        }
-        return nil
-    }
+    private static let renderer = MenuBarImageRenderer()
 
     var body: some View {
-        if let nsImage = renderImage() {
+        if let nsImage = Self.renderer.render(title: title, referenceTitle: referenceTitle) {
             Image(nsImage: nsImage)
         } else {
             Text(title)
         }
+    }
+}
+
+final class MenuBarImageRenderer {
+    private var cachedTitle: String = ""
+    private var cachedImage: NSImage? = nil
+    private let font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+    private let monoFont = NSFont.monospacedDigitSystemFont(
+        ofSize: NSFont.systemFontSize,
+        weight: .regular
+    )
+
+    func render(title: String, referenceTitle: String) -> NSImage? {
+        if title == cachedTitle, let image = cachedImage {
+            return image
+        }
+
+        let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+        let refSize = attributedString(from: referenceTitle).size()
+        let titleAttr = attributedString(from: title)
+        let titleSize = titleAttr.size()
+        let width = max(refSize.width, titleSize.width)
+        let height = max(refSize.height, titleSize.height)
+        let size = NSSize(width: ceil(width), height: ceil(height))
+
+        let image = NSImage(size: size)
+        image.isTemplate = true
+
+        image.lockFocus()
+        let drawRect = NSRect(
+            x: (size.width - titleSize.width) / 2,
+            y: (size.height - titleSize.height) / 2,
+            width: titleSize.width,
+            height: titleSize.height
+        )
+        titleAttr.draw(in: drawRect)
+        image.unlockFocus()
+
+        if let rep = image.representations.first as? NSBitmapImageRep {
+            rep.size = NSSize(width: size.width / scale, height: size.height / scale)
+        }
+
+        cachedTitle = title
+        cachedImage = image
+        return image
+    }
+
+    private let timeRegex = /[0-9]+:[0-9]{2}/
+
+    private func attributedString(from string: String) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        var currentIndex = string.startIndex
+
+        for match in string.matches(of: timeRegex) {
+            let prefix = String(string[currentIndex..<match.range.lowerBound])
+            if !prefix.isEmpty {
+                result.append(NSAttributedString(
+                    string: prefix,
+                    attributes: [.font: font]
+                ))
+            }
+            result.append(NSAttributedString(
+                string: String(string[match.range]),
+                attributes: [.font: monoFont]
+            ))
+            currentIndex = match.range.upperBound
+        }
+
+        let suffix = String(string[currentIndex...])
+        if !suffix.isEmpty {
+            result.append(NSAttributedString(
+                string: suffix,
+                attributes: [.font: font]
+            ))
+        }
+
+        return result
     }
 }

--- a/Uljika/MenuBarTitleLabel.swift
+++ b/Uljika/MenuBarTitleLabel.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import AppKit
+
+struct MenuBarTitleLabel: View {
+    let title: String
+    let referenceTitle: String
+    
+    // 好きなフォントがある場合はここで指定できるよ
+    
+    private func styledText(from string: String) -> Text {
+        let regex = /[0-9]+:[0-9]{2}/
+        var result = Text("")
+        
+        var currentIndex = string.startIndex
+        for match in string.matches(of: regex) {
+            result = result + Text(String(string[currentIndex..<match.range.lowerBound]))
+            // 数字部分だけ等幅にする
+            result = result + Text(String(string[match.range])).monospacedDigit()
+            currentIndex = match.range.upperBound
+        }
+        
+        result = result + Text(String(string[currentIndex...]))
+        return result
+    }
+
+    @MainActor
+    private func renderImage() -> NSImage? {
+        let layout = ZStack(alignment: .center) {
+            styledText(from: referenceTitle)
+                .hidden()
+
+            styledText(from: title)
+                .lineLimit(1)
+        }
+        .fixedSize()
+
+        let renderer = ImageRenderer(content: layout)
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
+
+        if let nsImage = renderer.nsImage {
+            nsImage.isTemplate = true
+            return nsImage
+        }
+        return nil
+    }
+
+    var body: some View {
+        if let nsImage = renderImage() {
+            Image(nsImage: nsImage)
+        } else {
+            Text(title)
+        }
+    }
+}

--- a/Uljika/TimeCalculator.swift
+++ b/Uljika/TimeCalculator.swift
@@ -29,35 +29,35 @@ class TimeCalculator {
     var title = "??まで--:--"
 
     init(settings: AppSettings) {
-        self.settings = settings
+            self.settings = settings
 
-        let date = Date()
-        let components = Self.calendar.dateComponents(
-            [.hour, .minute, .second],
-            from: date
-        )
+            let date = Date()
+            let components = Self.calendar.dateComponents(
+                [.hour, .minute, .second],
+                from: date
+            )
 
-        refreshNextSchedule(
-            nowSecs: (components.hour ?? 0) * 3600 + (components.minute ?? 0)
-                * 60
-        )
-        do {
-            try updateRemainingTime()
-        } catch {
-            print("タイマー更新中にエラーが発生: \(error)")
-        }
-
-        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
-            [weak self] _ in
-            MainActor.assumeIsolated {
-                do {
-                    try self?.updateRemainingTime()
-                } catch {
-                    print("タイマー更新中にエラーが発生: \(error)")
+            refreshNextSchedule(
+                nowSecs: (components.hour ?? 0) * 3600 + (components.minute ?? 0)
+                    * 60
+            )
+            do {
+                try updateRemainingTime()
+            } catch {
+                print("タイマー更新中にエラーが発生: \(error)")
+            }
+            let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
+                [weak self] _ in
+                MainActor.assumeIsolated {
+                    do {
+                        try self?.updateRemainingTime()
+                    } catch {
+                        print("タイマー更新中にエラーが発生: \(error)")
+                    }
                 }
             }
+            RunLoop.main.add(timer, forMode: .common)
         }
-    }
 
     private func updateRemainingTime() throws {
         let now = Date()

--- a/Uljika/TimeCalculator.swift
+++ b/Uljika/TimeCalculator.swift
@@ -5,7 +5,7 @@ import SwiftUI
 @Observable
 class TimeCalculator {
     static let schedules: [(String, Int)] = [
-        ("朝礼", 9 * 3600 + 31 * 60),
+        ("朝礼", 9 * 3600 + 30 * 60),
         ("1限目", 9 * 3600 + 45 * 60),
         ("休憩1", 10 * 3600 + 35 * 60),
         ("2限目", 10 * 3600 + 45 * 60),

--- a/Uljika/UljikaApp.swift
+++ b/Uljika/UljikaApp.swift
@@ -1,8 +1,5 @@
-import Combine
-import SwiftData
 import SwiftUI
-
-
+import AppKit
 
 @main
 struct UljikaApp: App {
@@ -12,7 +9,6 @@ struct UljikaApp: App {
 
     init() {
         let settings = AppSettings()
-
         self.settings = settings
         self.calculator = TimeCalculator(settings: settings)
     }
@@ -30,7 +26,13 @@ struct UljikaApp: App {
             Button("アプリを終了") { NSApplication.shared.terminate(nil) }
                 .keyboardShortcut("q", modifiers: .command)
         } label: {
-            Text(calculator.title)
+            MenuBarTitleLabel(
+                title: calculator.title,
+                referenceTitle: MenuBarLayoutHelper.referenceTitle(
+                    for: settings.renderStyle,
+                    fallbackText: settings.fallbackText
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
メニューバーの秒数を画像化することで横ずれ防止
さらにメニュー展開中に秒数が動かないバグも修正